### PR TITLE
Branch separation for `drafting` and `main`

### DIFF
--- a/.github/workflows/create-pdf.yml
+++ b/.github/workflows/create-pdf.yml
@@ -2,9 +2,9 @@ name: Create PDF
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, drafting ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, drafting ]
   workflow_dispatch:
 
 jobs:
@@ -28,6 +28,11 @@ jobs:
           name: cv
           path: cv/cv.pdf
           compression-level: 0 # don't compress PDF
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    steps:
       - name: Tag
         id: generate_release_tag
         uses: amitsingh-007/next-release-tag@v5.1.0

--- a/.github/workflows/create-pdf.yml
+++ b/.github/workflows/create-pdf.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main, drafting ]
   pull_request:
-    branches: [ main, drafting ]
+    branches: [ drafting ]
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ TODO.
 
 TODO.
 
+## Development
+
+Changes take place in the `drafting` branch. The `main` branch serves as the latest stable and released version of the CV, including its contents and the methods for generating it. When a CV draft is ready for release, make a pull request to merge the draft into `main`. If all checks pass, complete the merge to build and release a new version of the CV. Versions are formatted with `v{yyyy}.{mm}.{dd}.{i}`, e.g., [v2024.5.4.1](https://github.com/aridyckovsky/cv/releases/tag/v2024.5.4.1). Multiple versions within a day are tracked by an increasing sequence of natural numbers `i`.
+
 ## Acknowledgements
 
 This automation is made possible with the help of great open source contributiosn like:


### PR DESCRIPTION
Addresses part of #2 by enforcing a condition for tag-and-release (i.e., the `deploy` job): only when `drafting` is merged into `main` will that part of the workflow run.